### PR TITLE
ThreadedRepeatingFunctionRunner: Name all the threads

### DIFF
--- a/folly/experimental/ThreadedRepeatingFunctionRunner.h
+++ b/folly/experimental/ThreadedRepeatingFunctionRunner.h
@@ -120,7 +120,8 @@ class ThreadedRepeatingFunctionRunner final {
   /**
    * Run your noexcept function `f` in a background loop, sleeping between
    * calls for a duration returned by `f`.  Optionally waits for
-   * `initialSleep` before calling `f` for the first time.
+   * `initialSleep` before calling `f` for the first time.  Names the thread
+   * using up to the first 15 chars of `name`.
    *
    * DANGER: If a non-final class has a ThreadedRepeatingFunctionRunner
    * member (which, by the way, must be declared last in the class), then
@@ -130,6 +131,7 @@ class ThreadedRepeatingFunctionRunner final {
    * your threads.
    */
   void add(
+      std::string name,
       RepeatingFn f,
       std::chrono::milliseconds initialSleep = std::chrono::milliseconds(0));
 

--- a/folly/experimental/test/ThreadedRepeatingFunctionRunnerTest.cpp
+++ b/folly/experimental/test/ThreadedRepeatingFunctionRunnerTest.cpp
@@ -27,7 +27,7 @@ struct Foo {
   }
 
   void start() {
-    runner_.add([this]() {
+    runner_.add("Foo", [this]() {
       ++data;
       return std::chrono::seconds(0);
     });
@@ -45,7 +45,7 @@ struct FooLongSleep {
   }
 
   void start() {
-    runner_.add([this]() {
+    runner_.add("FooLongSleep", [this]() {
       data.store(1);
       return 1000h; // Test would time out if we waited
     });


### PR DESCRIPTION
Summary: Name all repeating function threads for ease of debugging.

Reviewed By: yfeldblum

Differential Revision: D5065281

fbshipit-source-id: e875e654dfa644a265e44416baf5fbf23c9da434